### PR TITLE
Remove windows 32 bits version

### DIFF
--- a/inkscape/__init__.py
+++ b/inkscape/__init__.py
@@ -36,11 +36,5 @@ def get():
             url=f"https://inkscape.org/release/inkscape-{version}/windows/64-bit/exe/dl/",
             arch='x86_64',
             os='windows'
-        ),
-        download_data(
-            version,
-            url=f"https://inkscape.org/release/inkscape-{version}/windows/32-bit/exe/dl/",
-            arch='x86',
-            os='windows'
         )
     ]


### PR DESCRIPTION
Inkscape només produeix ja la versió de 64 bits de Windows, la de 32 bits dona error perquè ja no existeix